### PR TITLE
Use npx for swa cli

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -56,6 +56,4 @@ jobs:
         path: dist
 
     - name: Deploy to Static Web App
-      run: |
-        npm i -g @azure/static-web-apps-cli
-        swa deploy ./dist/ --env production --app-name stapp-graffias --no-use-keychain
+      run: npx -y @azure/static-web-apps-cli deploy ./dist/ --env production --app-name stapp-graffias --no-use-keychain


### PR DESCRIPTION
This pull request includes a change to the deployment process in the `frontend-deploy.yml` workflow file. The change updates the command used for deploying to a static web app.

Deployment process update:

* [`.github/workflows/frontend-deploy.yml`](diffhunk://#diff-a9e1ff495f281c0fced65a796c69b5bcb77196eb9d20622b90a1837d260e637fL59-R59): Replaced the `npm i -g @azure/static-web-apps-cli` command with `npx -y @azure/static-web-apps-cli` to streamline the deployment process.