### PR TITLE
Fix code review findings: infra .NET version, metadata URL reuse, fetch resilience

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -7,9 +7,6 @@ on:
       - .github/workflows/frontend-deploy.yml
       - frontend/**
 
-env:
-  NODE_VERSION: 22.x
-
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/frontend/src/components/Platform.vue
+++ b/frontend/src/components/Platform.vue
@@ -3,10 +3,11 @@ import { ref } from 'vue'
 import { Platform } from '../types/Models'
 import { formatRelativeTime } from '../utils/FormatDate'
 import { regionData } from '../constants/Regions'
+import { metadataUrl } from '../constants/Metadata'
 
 const props = defineProps<{ region: string }>()
 
-const response = await fetch(`https://stgraffias.blob.core.windows.net/metadata/${props.region}/platform.json`)
+const response = await fetch(metadataUrl(props.region, 'platform'))
 
 if (!response.ok) {
   throw new Error(`Failed to load platform data (${response.status})`)

--- a/frontend/src/components/Runtime.vue
+++ b/frontend/src/components/Runtime.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Runtime } from '../types/Models'
+import { metadataUrl } from '../constants/Metadata'
 
 const props = defineProps<{ region: string }>()
 
-const response = await fetch(`https://stgraffias.blob.core.windows.net/metadata/${props.region}/runtime.json`)
+const response = await fetch(metadataUrl(props.region, 'runtime'))
 
 if (!response.ok) {
   throw new Error(`Failed to load runtime data (${response.status})`)

--- a/frontend/src/components/SiteExtension.vue
+++ b/frontend/src/components/SiteExtension.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { SiteExtension } from '../types/Models'
+import { metadataUrl } from '../constants/Metadata'
 
 const props = defineProps<{ region: string }>()
 
-const response = await fetch(`https://stgraffias.blob.core.windows.net/metadata/${props.region}/site-extension.json`)
+const response = await fetch(metadataUrl(props.region, 'site-extension'))
 
 if (!response.ok) {
   throw new Error(`Failed to load site extension data (${response.status})`)

--- a/frontend/src/composables/useRegionData.ts
+++ b/frontend/src/composables/useRegionData.ts
@@ -1,8 +1,7 @@
 import { Platform, Runtime, SiteExtension, createEmptyPlatform, createEmptyRuntime } from '../types/Models'
 import { allRegions } from '../constants/Regions'
+import { metadataUrl } from '../constants/Metadata'
 import { getUpdatedAt } from '../utils/FormatDate'
-
-const METADATA_BASE_URL = 'https://stgraffias.blob.core.windows.net/metadata'
 
 export type RegionData = {
   platformMap: Map<string, Platform>
@@ -11,31 +10,48 @@ export type RegionData = {
   platformUpdatedAtMap: Map<string, string>
 }
 
+// A single unreachable region (network error / invalid JSON) must not fail the whole
+// snapshot, so each fetch degrades to empty data instead of rejecting.
+async function fetchPlatform(region: string): Promise<[string, Platform, string]> {
+  try {
+    const response = await fetch(metadataUrl(region, 'platform'))
+
+    if (!response.ok) {
+      return [region, createEmptyPlatform(), '']
+    }
+
+    return [region, await response.json() as Platform, getUpdatedAt(response)]
+  }
+  catch {
+    return [region, createEmptyPlatform(), '']
+  }
+}
+
+async function fetchRuntime(region: string): Promise<[string, Runtime]> {
+  try {
+    const response = await fetch(metadataUrl(region, 'runtime'))
+    return [region, response.ok ? await response.json() as Runtime : createEmptyRuntime()]
+  }
+  catch {
+    return [region, createEmptyRuntime()]
+  }
+}
+
+async function fetchSiteExtensions(region: string): Promise<[string, SiteExtension[]]> {
+  try {
+    const response = await fetch(metadataUrl(region, 'site-extension'))
+    return [region, response.ok ? await response.json() as SiteExtension[] : []]
+  }
+  catch {
+    return [region, []]
+  }
+}
+
 export async function fetchRegionData(): Promise<RegionData> {
   const [platformEntries, runtimeEntries, siteExtensionEntries] = await Promise.all([
-    Promise.all(
-      allRegions.map(async (region): Promise<[string, Platform, string]> => {
-        const response = await fetch(`${METADATA_BASE_URL}/${region}/platform.json`)
-
-        if (!response.ok) {
-          return [region, createEmptyPlatform(), '']
-        }
-
-        return [region, await response.json() as Platform, getUpdatedAt(response)]
-      }),
-    ),
-    Promise.all(
-      allRegions.map(async (region): Promise<[string, Runtime]> => {
-        const response = await fetch(`${METADATA_BASE_URL}/${region}/runtime.json`)
-        return [region, response.ok ? await response.json() as Runtime : createEmptyRuntime()]
-      }),
-    ),
-    Promise.all(
-      allRegions.map(async (region): Promise<[string, SiteExtension[]]> => {
-        const response = await fetch(`${METADATA_BASE_URL}/${region}/site-extension.json`)
-        return [region, response.ok ? await response.json() as SiteExtension[] : []]
-      }),
-    ),
+    Promise.all(allRegions.map(fetchPlatform)),
+    Promise.all(allRegions.map(fetchRuntime)),
+    Promise.all(allRegions.map(fetchSiteExtensions)),
   ])
 
   return {

--- a/frontend/src/constants/Metadata.ts
+++ b/frontend/src/constants/Metadata.ts
@@ -1,0 +1,7 @@
+export const METADATA_BASE_URL = 'https://stgraffias.blob.core.windows.net/metadata'
+
+export type MetadataKind = 'platform' | 'runtime' | 'site-extension'
+
+export function metadataUrl(region: string, kind: MetadataKind): string {
+  return `${METADATA_BASE_URL}/${region}/${kind}.json`
+}

--- a/infra/modules/backend/main.tf
+++ b/infra/modules/backend/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_windows_web_app" "default" {
 
     application_stack {
       current_stack  = "dotnet"
-      dotnet_version = "v9.0"
+      dotnet_version = "v10.0"
     }
   }
 }

--- a/infra/modules/common/main.tf
+++ b/infra/modules/common/main.tf
@@ -22,7 +22,7 @@ resource "azurerm_storage_account" "default" {
     }
 
     container_delete_retention_policy {
-      days    = 7
+      days = 7
     }
 
     cors_rule {
@@ -37,6 +37,6 @@ resource "azurerm_storage_account" "default" {
 
 resource "azurerm_storage_container" "default" {
   name                  = "metadata"
-  storage_account_id  = azurerm_storage_account.default.id
+  storage_account_id    = azurerm_storage_account.default.id
   container_access_type = "blob"
 }


### PR DESCRIPTION
## Summary

Follow-up fixes from a codebase review, ordered by priority.

### Medium
- **Infra .NET version drift** — `infra/modules/backend/main.tf` pinned the App Service stack to `dotnet_version = "v9.0"`, but the backend targets `net10.0-windows` (csproj) and CI publishes framework-dependent with `DOTNET_VERSION: 10.0.x`. A `terraform apply` would set the plan to 9.0, and a framework-dependent .NET 10 app can fail to start on a 9.0 stack (major roll-forward is disabled by default). Bumped to `v10.0` (verified as a valid value in azurerm 4.74.0).
- **Duplicated metadata URL** — the blob base URL was hardcoded in 4 files. Extracted into a shared `frontend/src/constants/Metadata.ts` (`METADATA_BASE_URL` + `metadataUrl(region, kind)`) and reused everywhere.
- **Fetch resilience** — `fetchRegionData` only handled HTTP error status; a network-level rejection or invalid JSON for a single region rejected the whole `Promise.all`, failing the entire Home matrix / Timeline. Each region fetch now `try/catch`es and degrades to empty data, so one unreachable region no longer breaks the snapshot.

### Low
- Removed the unused `NODE_VERSION: 22.x` env from `frontend-deploy.yml` (the node version actually comes from `package.json` volta via `node-version-file`).
- `terraform fmt` on `infra/modules/common/main.tf` (whitespace alignment only).

## Verification
- `eslint .` — clean
- `vue-tsc --noEmit` — no type errors
- `terraform fmt -check -recursive` — clean
- Backend C# unchanged (not rebuilt)

## Notes for reviewer
A few lower-priority items from the review were intentionally left out as they need a design decision: the backend `Enabled` field being dropped by the frontend type, backend controller exception resilience, `PlatformInfo` `set`/`init` consistency, and a couple of minor frontend simplifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
